### PR TITLE
商品更新機能を作成しよう

### DIFF
--- a/src/app/api/inventory/products/[id]/route.ts
+++ b/src/app/api/inventory/products/[id]/route.ts
@@ -52,3 +52,34 @@ export async function DELETE(
     );
   }
 }
+
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  const { id } = await params;
+  try {
+    const body = await req.json();
+    const response = await fetch(`http://localhost:3001/products/${id}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      throw new Error("Failed to update product");
+    }
+
+    const product = await response.json();
+
+    return NextResponse.json(product, { status: 200 });
+  } catch (err) {
+    console.error(err);
+    return NextResponse.json(
+      { error: "Failed to update product" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/components/ProductMain.tsx
+++ b/src/components/ProductMain.tsx
@@ -14,6 +14,12 @@ export default function ProductMain() {
     price: 0,
     description: "",
   });
+  const [editProduct, setEditProduct] = useState<Product>({
+    id: null,
+    name: "",
+    price: 0,
+    description: "",
+  });
 
   const { message, severity, visible, showAlert } = useAlert();
 
@@ -129,6 +135,71 @@ export default function ProductMain() {
     }
   };
 
+  // 商品編集ボタンクリック時の処理
+  const handleShowEditForm = (product: Product) => {
+    setEditProduct(product);
+  };
+
+  // 商品編集フォームの入力値変更時の処理
+  const handleEditInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setEditProduct((prevProduct) => ({
+      ...prevProduct,
+      [name]: value,
+    }));
+  };
+
+  // 商品編集フォームの数値入力値変更時の処理
+  const handleEditNumberInputChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const { name, value } = e.target;
+    setEditProduct((prevProduct) => ({
+      ...prevProduct,
+      [name]: Number(value),
+    }));
+  };
+
+  // 商品編集フォームの更新ボタンクリック時の処理
+  const handleUpdate = async () => {
+    try {
+      const response = await fetch(
+        `http://localhost:3000/api/inventory/products/${editProduct.id}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(editProduct),
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error("商品更新に失敗しました");
+      }
+
+      showAlert("商品を更新しました", "success");
+      setEditProduct({
+        id: null,
+        name: "",
+        price: 0,
+        description: "",
+      });
+      fetchProducts();
+    } catch (error) {
+      showAlert("エラーが発生しました", "error");
+    }
+  };
+  // 商品編集フォームのキャンセルボタンクリック時の処理
+  const handleCancelEdit = () => {
+    setEditProduct({
+      id: null,
+      name: "",
+      price: 0,
+      description: "",
+    });
+  };
+
   useEffect(() => {
     fetchProducts();
   }, [fetchProducts]);
@@ -210,27 +281,87 @@ export default function ProductMain() {
           )}
           {products.map((product) => (
             <tr key={product.id} className="hover:bg-gray-50">
-              <td className="py-2 px-4 border-b">{product.id}</td>
-              <td className="py-2 px-4 border-b">{product.name}</td>
-              <td className="py-2 px-4 border-b">{product.price}</td>
-              <td className="py-2 px-4 border-b">{product.description}</td>
-              <td className="py-2 px-4 border-b">
-                <Link
-                  href={`/inventory/products/${product.id}`}
-                  className="text-blue-500 hover:text-blue-700 hover:underline"
-                >
-                  在庫処理
-                </Link>
-              </td>
-              <td className="py-2 px-4 border-b">
-                <button
-                  type="button"
-                  className="bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600 cursor-pointer"
-                  onClick={() => handleDelete(product.id)}
-                >
-                  削除
-                </button>
-              </td>
+              {editProduct.id === product.id ? (
+                <>
+                  <td className="py-2 px-4 border-b">{product.id}</td>
+                  <td className="py-2 px-4 border-b">
+                    <input
+                      type="text"
+                      name="name"
+                      value={editProduct.name}
+                      onChange={handleEditInputChange}
+                      className="border border-gray-300 rounded px-2 py-1 w-full"
+                    />
+                  </td>
+                  <td className="py-2 px-4 border-b">
+                    <input
+                      type="number"
+                      name="price"
+                      value={editProduct.price}
+                      onChange={handleEditNumberInputChange}
+                      className="border border-gray-300 rounded px-2 py-1 w-full"
+                    />
+                  </td>
+                  <td className="py-2 px-4 border-b">
+                    <input
+                      type="text"
+                      name="description"
+                      value={editProduct.description}
+                      onChange={handleEditInputChange}
+                      className="border border-gray-300 rounded px-2 py-1 w-full"
+                    />
+                  </td>
+                  <td className="py-2 px-4 border-b">
+                    <button
+                      type="button"
+                      className="bg-green-500 text-white py-2 px-4 rounded"
+                      onClick={handleUpdate}
+                    >
+                      更新
+                    </button>
+                  </td>
+                  <td className="py-2 px-4 border-b">
+                    <button
+                      type="button"
+                      className="bg-gray-500 text-white py-2 px-4 rounded"
+                      onClick={handleCancelEdit}
+                    >
+                      キャンセル
+                    </button>
+                  </td>
+                </>
+              ) : (
+                <>
+                  <td className="py-2 px-4 border-b">{product.id}</td>
+                  <td className="py-2 px-4 border-b">{product.name}</td>
+                  <td className="py-2 px-4 border-b">{product.price}</td>
+                  <td className="py-2 px-4 border-b">{product.description}</td>
+                  <td className="py-2 px-4 border-b">
+                    <Link
+                      href={`/inventory/products/${product.id}`}
+                      className="text-blue-500 hover:text-blue-700 hover:underline"
+                    >
+                      在庫処理
+                    </Link>
+                  </td>
+                  <td className="py-2 px-4 border-b">
+                    <button
+                      type="button"
+                      className="bg-yellow-500 text-white py-2 px-4 rounded"
+                      onClick={() => handleShowEditForm(product)}
+                    >
+                      編集
+                    </button>
+                    <button
+                      type="button"
+                      className="bg-green-500 text-white py-2 px-4 rounded hover:bg-green-600 cursor-pointer"
+                      onClick={() => handleDelete(product.id)}
+                    >
+                      削除
+                    </button>
+                  </td>
+                </>
+              )}
             </tr>
           ))}
         </tbody>

--- a/src/types/Product.ts
+++ b/src/types/Product.ts
@@ -1,5 +1,5 @@
 export type Product = {
-  id: number;
+  id: number | null;
   name: string;
   price: number;
   description: string;


### PR DESCRIPTION
このプルリクエストは、在庫管理システムで製品を編集する機能を導入します。これには、製品更新を処理するためのAPIルートの変更、インライン編集フォームをサポートするための`ProductMain`コンポーネントの更新、およびnullableなIDに対応するための`Product`型の変更が含まれます。

### APIの機能強化:
* IDによる製品詳細の更新を処理するための新しい`PUT`ハンドラーを`src/app/api/inventory/products/[id]/route.ts`に追加しました。これには、更新失敗時のエラー処理が含まれます。([src/app/api/inventory/products/[id]/route.tsR55-R85](diffhunk://#diff-15d0948b128c1610c7c79c723eb9f367ff18c3fa9968fa107f7326850dade88aR55-R85))

### フロントエンドの機能強化:
* **状態管理**: 編集中の製品を追跡するために、`src/components/ProductMain.tsx`に`editProduct`状態を追加しました。
* **編集フォームのロジック**:
    * `src/components/ProductMain.tsx`に、編集フォームの表示、入力値の更新、および編集の送信またはキャンセルを処理する関数を実装しました。
    * 製品テーブルにインライン編集フォームを統合し、ユーザーが製品の詳細を直接変更できるようにしました。 [[1]](diffhunk://#diff-b47f8fecae9c3bf45f5356bb881c4ab4951b57277b8603f29ae2370d250befc6R284-R334) [[2]](diffhunk://#diff-b47f8fecae9c3bf45f5356bb881c4ab4951b57277b8603f29ae2370d250befc6R363-R364)
* **編集ボタン**: 各製品行に、編集フォームをトリガーするための「編集」ボタンを追加しました。

### 型の更新:
* まだ保存されていない編集中​​の製品のシナリオに対応するために、`src/types/Product.ts`の`Product`型を更新し、`id`フィールドが`null`を許可するようにしました。