### PR TITLE
デバック実行するための設定を追加

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,40 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Next.js: Debug",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "skipFiles": ["<node_internals>/**"],
+      "outputCapture": "std",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "JSON Server: Debug",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "json-server"],
+      "skipFiles": ["<node_internals>/**"],
+      "outputCapture": "std",
+      "cwd": "${workspaceFolder}"
+    },
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Next.js: Debug in Chrome",
+      "url": "http://localhost:3000",
+      "webRoot": "${workspaceFolder}",
+      "sourceMaps": true,
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Next.js and JSON Server",
+      "configurations": ["Next.js: Debug", "JSON Server: Debug"]
+    }
+  ]
+}


### PR DESCRIPTION
このプルリクエストは、プロジェクトのデバッグを構成するための新しい`.vscode/launch.json`ファイルを追加します。この構成は、Next.jsアプリケーションとJSONサーバーの両方のデバッグをサポートし、ChromeでNext.jsアプリをデバッグするオプションも提供します。

**追加されたデバッグ構成:**

* **Next.jsのデバッグ**: `npm run dev`を使用してNext.jsアプリケーションのNode.jsデバッグセッションを構成します。
* **JSONサーバーのデバッグ**: `npm run json-server`を使用してJSONサーバーのNode.jsデバッグセッションを構成します。
* **ChromeでのNext.jsのデバッグ**: ソースマップを有効にして、ChromeでNext.jsアプリケーションをデバッグするためのサポートを追加します。

**複合構成:**

* **複合デバッグ**: Next.jsアプリケーションとJSONサーバーの両方を同時にデバッグするための複合構成を追加します。